### PR TITLE
Adds spidermonkey to play with experimental wasm features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ build-image:
 	cd docker && docker build --no-cache . -t ocaml-wasm-base
 
 build-sm:
-	cd docker/spidermonkey && docker build --no-cache . -t ocaml-wasm-spidermonkey
+	cd docker/spidermonkey && docker build . -t ocaml-wasm-spidermonkey
 
 run-sm:
 	docker run --name ocaml-wasm-spidermonkey --rm -it  ocaml-wasm-spidermonkey /sm-root/sm/js/src/build_OPT.OBJ/js/src/js

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,12 @@ clone:
 build-image:
 	cd docker && docker build --no-cache . -t ocaml-wasm-base
 
+build-sm:
+	cd docker/spidermonkey && docker build --no-cache . -t ocaml-wasm-spidermonkey
+
+run-sm:
+	docker run --name ocaml-wasm-spidermonkey --rm -it  ocaml-wasm-spidermonkey /sm-root/sm/js/src/build_OPT.OBJ/js/src/js
+
 run-container-dev:
 	docker run --name ocaml-wasm-bash --rm -dit -v `pwd`/workspace:/workspace:z ocaml-wasm-base bash	
 
@@ -29,7 +35,7 @@ copy-sources:
 	docker exec ocaml-wasm-bash ln -sf /workspace/Object /llvmwasm/llvm/lib/Object
 	docker exec ocaml-wasm-bash mv /wabt /workspace
 	docker exec ocaml-wasm-bash mv /ocaml /workspace
-	
+
 build-ocaml:
 	docker exec -w /workspace/ocaml ocaml-wasm-bash git checkout before_gc
 	docker exec -w /workspace/ocaml ocaml-wasm-bash ./configure -no-pthread -no-debugger -no-curses -no-ocamldoc -no-graph -target-wasm32 -cc clang

--- a/docker/spidermonkey/Dockerfile
+++ b/docker/spidermonkey/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:18.04
+
+RUN apt-get update
+RUN apt-get install -y wget
+RUN apt-get install -y python
+RUN apt-get install -y python3.6
+RUN apt-get install -y make
+RUN apt-get install -y autoconf2.13
+RUN apt-get install -y gcc
+RUN apt-get install -y g++
+RUN apt-get install -y clang
+
+WORKDIR /sm-root
+RUN wget https://hg.mozilla.org/mozilla-central/archive/tip.tar.gz
+RUN mkdir sm
+RUN tar -xf tip.tar.gz  --strip-components=1 -C sm
+
+WORKDIR /sm-root/sm
+RUN SHELL=$SHELL ./mach bootstrap --application-choice browser_artifact_mode --no-interactive || exit 0
+# exit 0 because Installing Stylo and NodeJS packages requires a checkout of mozilla-central.
+# Once you have such a checkout, please re-run `./mach bootstrap` from the
+# checkout directory. and we dont need them
+  
+WORKDIR /sm-root/sm/js/src
+RUN autoconf2.13
+RUN mkdir build_OPT.OBJ
+
+WORKDIR /sm-root/sm/js/src/build_OPT.OBJ
+RUN SHELL=$SHELL ../configure
+RUN SHELL=$SHELL make
+RUN make install


### PR DESCRIPTION
Tested on Windows and Mac. I believe it should work on Linux too since it was originally created on Arch, but couldn't find time to run it once.

Oh, and if we wish to support Windows properly, we must find an alternative to make (ideally, although mingw is already there).